### PR TITLE
Clear cache if size is over configured percentage (defaults to 90%)

### DIFF
--- a/config/src/manager.rs
+++ b/config/src/manager.rs
@@ -24,6 +24,10 @@ const fn _default_overlay_size() -> u32 {
     10 // 10GB
 }
 
+const fn _default_max_cache_pct() -> u8 {
+    90
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct Role {
     pub name: String,
@@ -38,6 +42,8 @@ pub struct Role {
     pub instance_count: u8,
     #[serde(default)]
     pub cache_paths: Vec<Utf8PathBuf>,
+    #[serde(default = "_default_max_cache_pct")]
+    pub max_cache_pct: u8,
     #[serde(default)]
     pub labels: Vec<String>,
 }

--- a/util/src/fs.rs
+++ b/util/src/fs.rs
@@ -54,6 +54,29 @@ pub fn dd(path: impl AsRef<Utf8Path>, size_in_mb: u64) -> std::io::Result<()> {
     Ok(())
 }
 
+pub fn du(path: impl AsRef<Utf8Path>) -> std::io::Result<u64> {
+    let path = path.as_ref();
+
+    let du_output = exec(Command::new("du").args([&path.as_str()]))
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    let size = du_output
+        .split_whitespace()
+        .next()
+        .ok_or(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Couldn not split '{:?}' into number and rest", du_output),
+        ))?;
+
+    size.parse().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Could not parse '{:?}' to number: {}", size, e),
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Before each run, check the cache image size (it's sparsely created, so we know the usage). If it's over the configured percentage, re-create the cache.