### PR TITLE
Fix release workflow: bump Rust toolchain and add workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and upload assets for"
+        required: true
 
 jobs:
   release:
@@ -8,11 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SRC_DIR: "bin"
-          TOOLCHAIN_VERSION: "1.74.0"
+          TOOLCHAIN_VERSION: "1.88.0"
         with:
           RUSTTARGET: x86_64-unknown-linux-musl


### PR DESCRIPTION
## Summary

- Bumps `TOOLCHAIN_VERSION` from `1.74.0` to `1.88.0` — the Cargo.lock now uses format version 4 (introduced in Rust 1.78), which caused the build to fail with _"lock file version 4 was found, but this version of Cargo does not understand this lock file"_
- Adds `workflow_dispatch` with a `tag` input so the build can be triggered manually for any existing release without needing to delete and recreate it

## Test plan

- [ ] Merge this PR
- [ ] Trigger the workflow manually for the existing `0.1.5` release: `gh workflow run release.yml --repo appsignal/actions-runner --field tag=0.1.5`
- [ ] Verify `actions-runner_v0.1.5_x86_64-unknown-linux-musl.zip` is attached to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)