### PR TITLE
Fix workflow_dispatch upload: pass correct GITHUB_REF for release lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SRC_DIR: "bin"
           TOOLCHAIN_VERSION: "1.88.0"
+          GITHUB_REF: refs/tags/${{ github.event.inputs.tag || github.ref_name }}
         with:
           RUSTTARGET: x86_64-unknown-linux-musl


### PR DESCRIPTION
When triggered via workflow_dispatch, GITHUB_REF points to the branch rather than the tag, so rust-build.action cannot locate the release to upload assets to. Override GITHUB_REF with the tag ref so the upload step finds the correct release.