### PR TITLE
Fix release upload: use UPLOAD_MODE as action input, add explicit upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,21 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
-      - name: Compile and release
+      - name: Compile
         uses: rust-build/rust-build.action@v1.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SRC_DIR: "bin"
           TOOLCHAIN_VERSION: "1.88.0"
-          GITHUB_REF: refs/tags/${{ github.event.inputs.tag || github.ref_name }}
         with:
           RUSTTARGET: x86_64-unknown-linux-musl
+          UPLOAD_MODE: none
+      - name: Package and upload
+        run: |
+          TAG=${{ github.event.inputs.tag || github.ref_name }}
+          ARCHIVE="actions-runner_v${TAG}_x86_64-unknown-linux-musl.zip"
+          zip "$ARCHIVE" target/x86_64-unknown-linux-musl/release/actions-runner
+          sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256sum"
+          gh release upload "$TAG" "$ARCHIVE" "${ARCHIVE}.sha256sum" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Moves `UPLOAD_MODE: none` from `env:` to `with:` — `rust-build.action` reads it as an action input, not an environment variable, so the previous placement was silently ignored and the action kept falling back to its default `release` upload mode
- Removes the `GITHUB_REF` override (it had no effect on the upload URL lookup)
- Adds an explicit **Package and upload** step: zips the compiled binary, creates a sha256sum, and uploads both to the release with `gh release upload --clobber`

## Test plan

- [ ] Merge this PR
- [ ] Trigger: `gh workflow run release.yml --repo appsignal/actions-runner --field tag=0.1.5`
- [ ] Verify: `gh release view 0.1.5 --repo appsignal/actions-runner --json assets --jq '.assets[].name'` returns `actions-runner_v0.1.5_x86_64-unknown-linux-musl.zip` and its sha256sum

🤖 Generated with [Claude Code](https://claude.com/claude-code)