### PR TITLE
Fix binary path in Package and upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           TAG=${{ github.event.inputs.tag || github.ref_name }}
           ARCHIVE="actions-runner_v${TAG}_x86_64-unknown-linux-musl.zip"
-          zip "$ARCHIVE" target/x86_64-unknown-linux-musl/release/actions-runner
+          zip "$ARCHIVE" bin/target/x86_64-unknown-linux-musl/release/actions-runner
           sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256sum"
           gh release upload "$TAG" "$ARCHIVE" "${ARCHIVE}.sha256sum" --clobber
         env:


### PR DESCRIPTION
## Summary

`SRC_DIR: "bin"` tells `rust-build.action` to compile from the `bin/` subdirectory, so the compiled binary lands at `bin/target/x86_64-unknown-linux-musl/release/actions-runner`, not `target/x86_64-unknown-linux-musl/release/actions-runner`. The zip step was failing with "name not matched".

## Test plan

- [ ] Merge this PR
- [ ] Trigger: `gh workflow run release.yml --repo appsignal/actions-runner --field tag=0.1.5`
- [ ] Verify: `gh release view 0.1.5 --repo appsignal/actions-runner --json assets --jq '.assets[].name'` returns `actions-runner_v0.1.5_x86_64-unknown-linux-musl.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)