### PR TITLE
Replace rust-build.action with native toolchain compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,20 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
-      - name: Compile
-        uses: rust-build/rust-build.action@v1.4.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SRC_DIR: "bin"
-          TOOLCHAIN_VERSION: "1.88.0"
+      - name: Install musl tools
+        run: sudo apt-get install -y musl-tools
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          RUSTTARGET: x86_64-unknown-linux-musl
-          UPLOAD_MODE: none
+          toolchain: "1.88.0"
+          targets: x86_64-unknown-linux-musl
+      - name: Build
+        run: cargo build --manifest-path bin/Cargo.toml --target x86_64-unknown-linux-musl --release
       - name: Package and upload
         run: |
           TAG=${{ github.event.inputs.tag || github.ref_name }}
           ARCHIVE="actions-runner_v${TAG}_x86_64-unknown-linux-musl.zip"
-          zip "$ARCHIVE" bin/target/x86_64-unknown-linux-musl/release/actions-runner
+          zip "$ARCHIVE" target/x86_64-unknown-linux-musl/release/actions-runner
           sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256sum"
           gh release upload "$TAG" "$ARCHIVE" "${ARCHIVE}.sha256sum" --clobber
         env:


### PR DESCRIPTION
## Summary

`rust-build.action` compiles inside a Docker container to an internal target directory that is NOT in the mounted workspace volume — so the binary is gone by the time the "Package and upload" step runs (both `target/...` and `bin/target/...` paths fail with "name not matched").

Replaced with the standard approach:
- `dtolnay/rust-toolchain` to install Rust 1.88.0 with the `x86_64-unknown-linux-musl` target
- `musl-tools` apt package for the musl C linker
- `cargo build --manifest-path bin/Cargo.toml --target x86_64-unknown-linux-musl --release` — binary lands at `target/x86_64-unknown-linux-musl/release/actions-runner` in the workspace
- Explicit zip + sha256sum + `gh release upload --clobber`

## Test plan

- [ ] Merge this PR
- [ ] Trigger: `gh workflow run release.yml --repo appsignal/actions-runner --field tag=0.1.5`
- [ ] Verify: `gh release view 0.1.5 --repo appsignal/actions-runner --json assets --jq '.assets[].name'` returns `actions-runner_v0.1.5_x86_64-unknown-linux-musl.zip` and its sha256sum

🤖 Generated with [Claude Code](https://claude.com/claude-code)