### PR TITLE
Pass LVM config to Instance on construction

### DIFF
--- a/manager/src/slot.rs
+++ b/manager/src/slot.rs
@@ -22,7 +22,8 @@ pub fn run_slot(config: Arc<ManagerConfig>, role: &Role, idx: usize) -> Result<(
         &config.run_path,
         role,
         idx as u8,
-    );
+    )
+    .with_lvm(&config.lvm);
 
     instance.setup().map_err(|e| {
         error!(role = %role.name, idx, error = %e, "slot setup failed");


### PR DESCRIPTION
## Summary

- `Instance::new()` initialises its `lvm` field with empty strings and has a `with_lvm()` builder method intended to populate it from `ManagerConfig`
- `with_lvm()` was never called at the construction site in `slot.rs`
- As a result, `lvcreate` was invoked with an empty volume group, producing paths like `/base-default` instead of `runners/base-default`, causing every slot boot cycle to fail with:
  ```
  "/rootfs-default-0": Invalid path for Logical Volume.
  Volume group name  has invalid characters
  lvcreate snapshot failed: /base-default -> rootfs-default-0
  ```

## Fix

Chain `.with_lvm(&config.lvm)` onto the `Instance::new()` call in `run_slot()`.

## Test plan

- [ ] Build and release a new version
- [ ] Deploy to ci-hel3 (staging manager node) and verify boot cycles succeed in `journalctl -u actions-runner`