### PR TITLE
Wait for udev to settle after thin snapshot creation

### DIFF
--- a/manager/src/lvm.rs
+++ b/manager/src/lvm.rs
@@ -79,6 +79,11 @@ pub fn lvcreate_snapshot(vg: &str, source: &str, name: &str) -> Result<()> {
         anyhow::bail!("lvcreate snapshot failed: {}/{} -> {}", vg, source, name);
     }
     info!(vg, source, name, "snapshot created");
+    // Wait for udev to process the new device node before returning so callers
+    // can immediately open or mount the device path under /dev.
+    let _ = Command::new("udevadm")
+        .args(["settle", "--timeout=5"])
+        .status();
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- After `lvcreate -s` succeeds the kernel fires a uevent, but the `/dev/<vg>/<lv>` device node is created **asynchronously** by udevd
- Mounting immediately after `lvcreate_snapshot` races against udev, producing `special device /dev/runners/rootfs-default-X does not exist` (exit status 32)
- Adds `udevadm settle --timeout=5` inside `lvcreate_snapshot` so the device node is guaranteed to exist before returning to callers
