### PR TITLE
Activate thin snapshot after creation with lvchange -K -ay

### DIFF
--- a/manager/src/lvm.rs
+++ b/manager/src/lvm.rs
@@ -78,12 +78,22 @@ pub fn lvcreate_snapshot(vg: &str, source: &str, name: &str) -> Result<()> {
     if !status.success() {
         anyhow::bail!("lvcreate snapshot failed: {}/{} -> {}", vg, source, name);
     }
-    info!(vg, source, name, "snapshot created");
-    // Wait for udev to process the new device node before returning so callers
-    // can immediately open or mount the device path under /dev.
+    // Thin snapshots are created with the "skip activation" flag (k) set by
+    // default. Plain lvchange -ay silently respects that flag and does nothing.
+    // -K (--ignoreactivationskip) overrides it, creating the DM device so the
+    // /dev/<vg>/<lv> node is present before we return.
+    let status = Command::new("lvchange")
+        .args(["-K", "-ay", &format!("{}/{}", vg, name)])
+        .status()
+        .context("failed to run lvchange -K -ay")?;
+    if !status.success() {
+        anyhow::bail!("lvchange -K -ay failed for {}/{}", vg, name);
+    }
+    // Wait for udev to finish creating the /dev/<vg>/<lv> symlink.
     let _ = Command::new("udevadm")
         .args(["settle", "--timeout=5"])
         .status();
+    info!(vg, source, name, "snapshot created and activated");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Thin LV snapshots are created with the **"skip activation" flag** (`k`) set by default on the LVM version running on ci-hel3 (Ubuntu 22.04)
- `lvchange -ay` silently respects that flag and does nothing — no DM device is ever created, `/dev/<vg>/<lv>` never appears, and `mount` fails with ENOENT (exit 32)
- Adds `lvchange -K -ay` (`--ignoreactivationskip`) immediately after `lvcreate -s`, followed by `udevadm settle` to ensure the `/dev` symlink is present before returning

**Manually confirmed on ci-hel3:**
```
# lvchange -K -ay runners/rootfs-default-0
# ls -la /dev/runners/rootfs-default-0
lrwxrwxrwx 1 root root 7 ... /dev/runners/rootfs-default-0 -> ../dm-5
# mount /dev/runners/rootfs-default-0 /tmp/test-mnt && echo "MOUNT OK"
MOUNT OK
```

## Test plan

- [ ] Review and merge
- [ ] Create release `v0.1.8`
- [ ] Bump `ci_actions_runner_manager_version` to `0.1.8` in ansible and deploy to ci-hel3
- [ ] Confirm boot cycles progress past the mount step and Firecracker VMs start

🤖 Generated with [Claude Code](https://claude.com/claude-code)