### PR TITLE
Inject /etc/resolv.conf into VM rootfs to fix DNS failure cycling

### DIFF
--- a/manager/src/inject.rs
+++ b/manager/src/inject.rs
@@ -33,7 +33,10 @@ MACAddress={guest_mac}
 [Network]
 Address={client_ip}/30
 Gateway={host_ip}
+DNS=1.1.1.1
 "#;
+
+const RESOLV_CONF: &str = "nameserver 1.1.1.1\noptions use-vc\n";
 
 /// Inject runner.service, eth.network, and service symlink into a mounted rootfs.
 #[instrument(skip(network), fields(mount_point = %mount_point, runner_name, role))]
@@ -47,6 +50,7 @@ pub fn inject_config(
 ) -> Result<()> {
     inject_runner_service(mount_point, github_org, github_token, runner_name, labels)?;
     inject_network_config(mount_point, network)?;
+    inject_resolv_conf(mount_point)?;
     enable_runner_service(mount_point)?;
     Ok(())
 }
@@ -91,6 +95,14 @@ fn inject_network_config(mount_point: &Utf8Path, network: &NetworkAllocation) ->
         .with_context(|| format!("failed to write {}", network_path))?;
 
     info!(path = %network_path, "injected eth.network");
+    Ok(())
+}
+
+fn inject_resolv_conf(mount_point: &Utf8Path) -> Result<()> {
+    let resolv_path = mount_point.join("etc/resolv.conf");
+    fs::write(&resolv_path, RESOLV_CONF)
+        .with_context(|| format!("failed to write {}", resolv_path))?;
+    info!(path = %resolv_path, "injected resolv.conf");
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

VMs on ci-hel3 were cycling every ~3 seconds. Diagnostic testing confirmed the root cause:

```
resolv.conf: [EMPTY]
ping 1.1.1.1: SUCCESS
DNS: FAILED
```

`systemd-networkd` clears `/etc/resolv.conf` when it takes over the interface. With `systemd-resolved` masked in the base image, networkd never writes DNS entries back to the file — even when `DNS=` is set in the `.network` unit. The result is an empty resolv.conf inside every VM.

`config.sh` tries to reach `api.github.com` on startup, gets a DNS failure, exits non-zero, and the `ExecStopPost=+/usr/sbin/reboot` in `runner.service` triggers an immediate reboot — producing the 3-second cycle.

## Fix

- Overwrite `/etc/resolv.conf` in `inject_config()` right after writing `eth.network`, so `nameserver 1.1.1.1` is always present regardless of what networkd does during boot.
- Also add `DNS=1.1.1.1` to the `eth.network` template as a belt-and-suspenders measure.

## Test plan

- [ ] Deploy new binary to ci-hel3
- [ ] Restart `actions-runner.service`
- [ ] Confirm runners appear in GitHub org settings (Settings → Actions → Runners)
- [ ] Confirm no more 3-second cycling in `journalctl -u actions-runner`