### PR TITLE
Route runner.service stdout/stderr to serial console

### DIFF
--- a/manager/src/inject.rs
+++ b/manager/src/inject.rs
@@ -23,7 +23,9 @@ KillSignal=SIGTERM
 TimeoutStopSec=5min
 WorkingDirectory=/home/runner
 User=runner
-Restart=never
+Restart=no
+StandardOutput=journal+console
+StandardError=journal+console
 ExecStopPost=+/usr/sbin/reboot
 "#;
 


### PR DESCRIPTION
## Summary

- `config.sh` and `run.sh` output was being sent to the systemd journal inside the VM, invisible to us — the console log only showed systemd's own startup/shutdown messages
- Add `StandardOutput=journal+console` and `StandardError=journal+console` so the runner's output appears in `console.log` (captured from Firecracker's stdout via ttyS0)
- Fix `Restart=never` → `Restart=no` (`never` is not a valid systemd restart specifier; systemd was already ignoring it and logging a warning at boot)

## Context

The VM boots, runner.service starts, and exits within ~2 seconds — triggering `ExecStopPost=+/usr/sbin/reboot`. We can see the service starts successfully but can't see *why* it exits. This change makes `config.sh`/`run.sh` output visible in the per-slot `console.log` file so the next boot cycle will reveal the actual failure.