### PR TITLE
Fix three cache LV bugs: cache_size ignored, cache-empty deleted by reconcile, GC threshold never firing

### DIFF
--- a/manager/src/disk.rs
+++ b/manager/src/disk.rs
@@ -32,20 +32,40 @@ impl CacheDisk {
         Ok(())
     }
 
-    /// Check cache usage percentage. Uses df on the mounted LV device.
+    /// Check cache usage as a percentage of the LV's virtual size.
+    ///
+    /// The cache LV is only ever mounted inside the guest VM (as /dev/vdb),
+    /// never on the host — so `df` on the host cannot see its filesystem and
+    /// reports the filesystem containing the device *node* (devtmpfs, ~0%)
+    /// instead, meaning the clear threshold never fires. Read the thin LV's
+    /// `data_percent` via lvs, which the host can always see. It slightly
+    /// overestimates after guest-side deletes (thin blocks aren't returned
+    /// without discard), which errs on the side of clearing — fine for a cache.
     pub fn usage_pct(&self) -> Result<u8> {
-        let output = std::process::Command::new("df")
-            .args(["--output=pcent", &self.device_path()])
+        let output = std::process::Command::new("lvs")
+            .args([
+                "--noheadings",
+                "--options",
+                "data_percent",
+                &format!("{}/{}", self.volume_group, self.lv_name),
+            ])
             .output()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        // Output: "Use%\n  42%\n"
-        let pct_str = stdout
-            .lines()
-            .nth(1)
-            .unwrap_or("0")
+        if !output.status.success() {
+            anyhow::bail!(
+                "lvs failed for {}/{}: {}",
+                self.volume_group,
+                self.lv_name,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        // Output: "  92.98" (some locales emit a comma decimal separator)
+        let raw = String::from_utf8_lossy(&output.stdout)
             .trim()
-            .trim_end_matches('%');
-        Ok(pct_str.parse().unwrap_or(0))
+            .replace(',', ".");
+        let pct: f64 = raw.parse().map_err(|e| {
+            anyhow::anyhow!("failed to parse lvs data_percent {:?}: {}", raw, e)
+        })?;
+        Ok(pct.round().clamp(0.0, 100.0) as u8)
     }
 
     /// Clear cache by removing and re-snapshotting from cache-empty.

--- a/manager/src/lvm.rs
+++ b/manager/src/lvm.rs
@@ -219,10 +219,17 @@ pub fn reconcile(config: &ManagerConfig) -> Result<()> {
     let existing_names: HashMap<&str, &LvInfo> =
         existing.iter().map(|lv| (lv.name.as_str(), lv)).collect();
 
-    // Ensure cache-empty exists
+    // Ensure cache-empty exists. Size it to the largest cache_size across all
+    // roles so any role can snapshot from it and get a sufficient disk.
     if !existing_names.contains_key("cache-empty") {
-        info!(vg, "creating cache-empty LV");
-        lvcreate_thin(vg, pool, "cache-empty", 1)?;
+        let cache_size_gib = config
+            .roles
+            .iter()
+            .map(|r| r.cache_size as u64)
+            .max()
+            .unwrap_or(1);
+        info!(vg, cache_size_gib, "creating cache-empty LV");
+        lvcreate_thin(vg, pool, "cache-empty", cache_size_gib)?;
         mkfs_ext4(&format!("/dev/{}/cache-empty", vg))?;
     }
 
@@ -254,6 +261,10 @@ pub fn reconcile(config: &ManagerConfig) -> Result<()> {
         }
         for prefix in ["rootfs-", "cache-"] {
             if let Some(rest) = lv.name.strip_prefix(prefix) {
+                // cache-empty is the shared template LV — never remove it here.
+                if lv.name == "cache-empty" {
+                    continue;
+                }
                 let role_slug = rest.rsplit_once('-').map(|(r, _)| r).unwrap_or(rest);
                 if !active_roles.contains(role_slug) {
                     lvremove(vg, &lv.name)?;


### PR DESCRIPTION
Fixes **three** bugs in the manager's cache-disk handling. Together they are the root cause of the staging CI disk-space incident of 2026-07-02, where every `appsignal-processor-rs` build went red with `No space left on device` on `/cache` (see appsignal-ansible#796 for the config-side half).

### Bug 1 — `cache_size` was ignored: `cache-empty` hardcoded to 1 GiB
`reconcile()` created the shared `cache-empty` template LV at a fixed **1 GiB**, and every slot cache LV is a thin snapshot of it — so the per-role `cache_size` config value never sized anything. Freshly provisioned hosts (ci-hel1, ci-hel2) ended up with **1 GiB** cache disks per VM where the config said 20 (and classic runners used to provide 100).

**Fix:** size `cache-empty` from `max(role.cache_size)` across all roles, so any role can snapshot from it and get a sufficient disk.

### Bug 2 — reconcile deleted its own `cache-empty` template
The stale-LV cleanup loop strips the `cache-` prefix, derives role slug `"empty"`, finds no such role, and **removes `cache-empty` on every reconcile** (i.e. every manager start, right after the slot snapshots are created). After that, `CacheDisk::clear()` — which re-snapshots from `cache-empty` — fails, so full caches can never be cleared.

**Fix:** guard the cleanup loop, `cache-empty` is the shared template, never remove it. (Audited all `lvremove` call sites; this loop is the only path that could delete it.)

### Bug 3 — GC threshold never fired: usage measured with `df` on the host
`CacheDisk::usage_pct()` ran `df --output=pcent /dev/<vg>/<lv>` **on the host**, but the cache LV is only ever mounted **inside the guest** (as `/dev/vdb`). For an unmounted block device, `df` reports the filesystem containing the device *node* — devtmpfs, ~0% — and any parse failure was silently coerced to 0 (`unwrap_or(0)`). So `try_clear_cache()` compared ~0% against `max_cache_pct` and **never cleared anything**, regardless of bugs 1–2. Production evidence: ci-hel3 slot caches sat at 92–98% `data_percent`, never trimmed.

**Fix:** read the thin LV's `data_percent` via `lvs`, which the host can always see. It slightly overestimates after guest-side deletes (thin blocks aren't returned without discard), erring on the side of clearing, fine for a cache. Failures now propagate as errors (surfaced as warnings by `try_clear_cache`) instead of being coerced to 0%, which is how this bug stayed hidden.

### Deployment notes
- `reconcile()` only creates missing LVs, it does **not** resize existing ones. Hosts already carrying manually rebuilt 100 GiB caches (ci-hel1/2/3, 2026-07-02) keep them and need nothing. To change `cache_size` on a running host later: `lvremove` the slot cache LVs + `cache-empty`, then restart the manager.
- Companion config change (cache_size 20→100, max_cache_pct 75) already merged in appsignal-ansible#796; it takes full effect once this ships (proposed **v0.1.12**) and `ci_actions_runner_manager_version` is bumped.
